### PR TITLE
feat(auth): implementa tela de login, JWT e middleware de protecao de…

### DIFF
--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+import bcrypt from "bcryptjs";
+import { createSession } from "@/lib/session";
+import { redirect } from "next/navigation";
+
+export async function login(prevState: any, formData: FormData) {
+    const email = formData.get("email") as string;
+    const password = formData.get("password") as string;
+
+    if (!email || !password) {
+        return { error: "Email e senha são obrigatórios" };
+    }
+
+    // user from db
+    const user = await prisma.user.findUnique({
+        where: { email },
+    });
+
+    if (!user || !user.password) {
+        return { error: "Credenciais inválidas" };
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, user.password);
+
+    if (!isPasswordValid) {
+        return { error: "Credenciais inválidas" };
+    }
+
+    await createSession(String(user.id));
+
+    redirect("/dashboard");
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useActionState } from "react";
+import { login } from "@/app/actions/auth";
+import { Loader2, Activity } from "lucide-react";
+
+export default function LoginPage() {
+    const [state, formAction, isPending] = useActionState(login, null);
+
+    return (
+        <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+            <div className="max-w-md w-full">
+                {/* Header */}
+                <div className="text-center mb-8">
+                    <div className="mx-auto w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mb-4 shadow-lg">
+                        <Activity className="h-8 w-8 text-white" />
+                    </div>
+                    <h1 className="text-3xl font-bold text-slate-900">UTI Care</h1>
+                    <p className="text-slate-500 mt-2">Sistema de Gestão de Leitos</p>
+                </div>
+
+                {/* Login Card */}
+                <div className="bg-white rounded-2xl shadow-xl p-8 border border-slate-100">
+                    <h2 className="text-xl font-semibold text-slate-800 mb-6 text-center">Acesso Restrito</h2>
+
+                    <form action={formAction} className="space-y-5">
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="email">
+                                E-mail Profissional
+                            </label>
+                            <input
+                                id="email"
+                                name="email"
+                                type="email"
+                                required
+                                placeholder="nome@hospital.com.br"
+                                className="w-full px-4 py-3 rounded-lg border border-slate-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+                                disabled={isPending}
+                            />
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="password">
+                                Senha
+                            </label>
+                            <input
+                                id="password"
+                                name="password"
+                                type="password"
+                                required
+                                placeholder="••••••••"
+                                className="w-full px-4 py-3 rounded-lg border border-slate-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+                                disabled={isPending}
+                            />
+                        </div>
+
+                        {state?.error && (
+                            <div className="p-3 rounded-lg bg-red-50 border border-red-100 text-red-600 text-sm text-center">
+                                {state.error}
+                            </div>
+                        )}
+
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 rounded-lg transition-colors flex items-center justify-center disabled:opacity-70 disabled:cursor-not-allowed"
+                        >
+                            {isPending ? (
+                                <>
+                                    <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                                    Entrando...
+                                </>
+                            ) : (
+                                "Entrar no Sistema"
+                            )}
+                        </button>
+                    </form>
+                </div>
+
+                {/* Footer */}
+                <p className="text-center text-sm text-slate-400 mt-8">
+                    &copy; {new Date().getFullYear()} UTI Care. Todos os direitos reservados.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,40 @@
+import { SignJWT, jwtVerify } from "jose";
+import { cookies } from "next/headers";
+
+const secretKey = process.env.JWT_SECRET || "fallback-secret-for-development-only-change-in-production";
+const encodedKey = new TextEncoder().encode(secretKey);
+
+export async function createSession(userId: string) {
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
+  
+  const session = await new SignJWT({ userId, expiresAt })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("24h")
+    .sign(encodedKey);
+
+  const cookieStore = await cookies();
+  cookieStore.set("session", session, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    expires: expiresAt,
+    sameSite: "lax",
+    path: "/",
+  });
+}
+
+export async function deleteSession() {
+  const cookieStore = await cookies();
+  cookieStore.delete("session");
+}
+
+export async function verifySession(session: string | undefined = "") {
+  try {
+    const { payload } = await jwtVerify(session, encodedKey, {
+      algorithms: ["HS256"],
+    });
+    return payload;
+  } catch (error) {
+    return null;
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { verifySession } from "./lib/session";
+
+export async function middleware(req: NextRequest) {
+    // Rotas protegidas (tudo dentro de /dashboard)
+    const isProtectedRoute = req.nextUrl.pathname.startsWith("/dashboard");
+    const isPublicRoute = req.nextUrl.pathname === "/login";
+
+    // Ler o cookie de sessão
+    const session = req.cookies.get("session")?.value;
+
+    // Decodificar a sessão
+    const payload = await verifySession(session);
+
+    // Redirecionar para login se for rota protegida e não tiver sessão válida
+    if (isProtectedRoute && !payload) {
+        return NextResponse.redirect(new URL("/login", req.nextUrl));
+    }
+
+    // Redirecionar para dashboard se já estiver logado e tentar acessar o login
+    if (isPublicRoute && payload) {
+        return NextResponse.redirect(new URL("/dashboard", req.nextUrl));
+    }
+
+    return NextResponse.next();
+}
+
+// Configurar matcher para quais rotas o middleware deve rodar
+export const config = {
+    matcher: ["/((?!api|_next/static|_next/image|.*\\.png$).*)"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@prisma/adapter-pg": "^7.1.0",
         "@prisma/client": "^7.1.0",
+        "bcryptjs": "^3.0.3",
         "dotenv": "^17.2.3",
+        "jose": "^6.2.1",
         "lucide-react": "^0.561.0",
         "next": "16.0.10",
         "pg": "^8.16.3",
@@ -19,6 +21,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
         "@types/pg": "^8.16.0",
         "@types/react": "^19",
@@ -2268,6 +2271,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3180,6 +3190,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/brace-expansion": {
@@ -5518,6 +5537,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@prisma/adapter-pg": "^7.1.0",
     "@prisma/client": "^7.1.0",
+    "bcryptjs": "^3.0.3",
     "dotenv": "^17.2.3",
+    "jose": "^6.2.1",
     "lucide-react": "^0.561.0",
     "next": "16.0.10",
     "pg": "^8.16.3",
@@ -20,6 +22,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",
     "@types/pg": "^8.16.0",
     "@types/react": "^19",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -224,3 +224,19 @@ model DraftEvolution {
   @@unique([bed_id, doctor_id]) // Um médico só tem 1 rascunho por leito
   @@map("draft_evolutions")
 }
+
+// ============================================
+// MODEL: User (Autenticação)
+// ============================================
+model User {
+  id         Int      @id @default(autoincrement())
+  name       String
+  email      String   @unique
+  password   String
+
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  @@map("users")
+}
+


### PR DESCRIPTION
feat(auth): implementa tela de login, JWT e middleware de proteção de rotas
Implementação completa do fluxo de autenticação para o sistema UTI Care.
## 🔧 O que foi feito
### Arquivos criados
| Arquivo | Descrição |
|---|---|
| `app/login/page.tsx` | Interface da tela de login (Tailwind CSS, responsiva) |
| `app/actions/auth.ts` | Server Action com validação de credenciais via `bcryptjs` |
| `lib/session.ts` | Gerenciamento de sessão JWT usando `jose` (criar, verificar, deletar) |
| `middleware.ts` | Middleware Edge para proteção das rotas `/dashboard/**` |
### Arquivos modificados
| Arquivo | Descrição |
|---|---|
| `prisma/schema.prisma` | Adicionado model `User` (id, name, email, password hash, timestamps) |
| `package.json` | Adicionadas dependências: `bcryptjs`, `jose`, `@types/bcryptjs` |
| `package-lock.json` | Lockfile atualizado |
### Nenhum arquivo existente foi removido ou teve lógica alterada
✅ Todas as Server Actions (`bedManagement.ts`, `patientData.ts`, `saveEvolution.ts`) permanecem intactas.  
✅ Dashboard, detalhes do leito e formulários de evolução clínica funcionam sem alterações.
## 🔐 Como funciona a autenticação
1. O `middleware.ts` intercepta qualquer acesso a `/dashboard/**`
2. Verifica o cookie `session` (JWT assinado com HS256 via `jose`)
3. Se inválido/expirado → redireciona para `/login`
4. Na tela de login, o usuário submete email + senha
5. A Server Action `login()` busca o User no banco, compara o hash com `bcryptjs`
6. Se válido → cria cookie JWT com expiração de 24h e redireciona para `/dashboard`
## ⚠️ Observações importantes para teste local
> Para rodar localmente, foram necessárias algumas configurações temporárias:
1. **Arquivo `.env`** — É preciso criar um `.env` na raiz com:
   ```env
   DATABASE_URL="postgresql://USUARIO:SENHA@HOST:PORTA/NOME_DO_BANCO"
   JWT_SECRET="uma-chave-secreta-segura"
   ```
   Este arquivo está no `.gitignore` e **não é versionado**.
2. **Gerar o Prisma Client** — A pasta `app/generated/prisma` (que também está no `.gitignore`) precisa ser gerada localmente:
   ```bash
   npx prisma generate
   ```
3. **Sincronizar o banco** — Para criar a tabela `users` no PostgreSQL:
   ```bash
   npx prisma db push
   ```
4. **Criar usuário de teste** — Não há seed automático. Use o Prisma Studio ou insira manualmente:
   ```bash
   npx prisma studio
   ```
   Crie um registro na tabela `users` com a senha em hash bcrypt.
## 📸 Screenshots
A tela de login foi testada e está responsiva (desktop e mobile).